### PR TITLE
Thesis #1: Replace in_array with Set lookups for special_words and line_starters

### DIFF
--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -39,6 +39,9 @@ var TOKEN = require('./tokenizer').TOKEN;
 
 
 function in_array(what, arr) {
+  if (arr instanceof Set) {
+    return arr.has(what);
+  }
   return arr.indexOf(what) !== -1;
 }
 
@@ -63,7 +66,7 @@ function reserved_array(token, words) {
   return token && token.type === TOKEN.RESERVED && in_array(token.text, words);
 }
 // Unsure of what they mean, but they work. Worth cleaning up in future.
-var special_words = ['case', 'return', 'do', 'if', 'throw', 'else', 'await', 'break', 'continue', 'async'];
+var special_words = new Set(['case', 'return', 'do', 'if', 'throw', 'else', 'await', 'break', 'continue', 'async']);
 
 var validPositionValues = ['before-newline', 'after-newline', 'preserve-newline'];
 

--- a/js/src/javascript/tokenizer.js
+++ b/js/src/javascript/tokenizer.js
@@ -38,6 +38,9 @@ var TemplatablePattern = require('../core/templatablepattern').TemplatablePatter
 
 
 function in_array(what, arr) {
+  if (arr instanceof Set) {
+    return arr.has(what);
+  }
   return arr.indexOf(what) !== -1;
 }
 
@@ -73,10 +76,10 @@ var digit = /[0-9]/;
 // Dot "." must be distinguished from "..." and decimal
 var dot_pattern = /[^\d\.]/;
 
-var positionable_operators = (
+var positionable_operators = new Set((
   ">>> === !== &&= ??= ||= " +
   "<< && >= ** != == <= >> || ?? |> " +
-  "< / - + > : & % ? ^ | *").split(' ');
+  "< / - + > : & % ? ^ | *").split(' '));
 
 // IMPORTANT: this must be sorted longest to shortest or tokenizing many not work.
 // Also, you must update possitionable operators separately from punct
@@ -94,8 +97,9 @@ punct = punct.replace(/ /g, '|');
 var punct_pattern = new RegExp(punct);
 
 // words which should always start on new line.
-var line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',');
-var reserved_words = line_starters.concat(['do', 'in', 'of', 'else', 'get', 'set', 'new', 'catch', 'finally', 'typeof', 'yield', 'async', 'await', 'from', 'as', 'class', 'extends']);
+var line_starters_array = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',');
+var line_starters = new Set(line_starters_array);
+var reserved_words = line_starters_array.concat(['do', 'in', 'of', 'else', 'get', 'set', 'new', 'catch', 'finally', 'typeof', 'yield', 'async', 'await', 'from', 'as', 'class', 'extends']);
 var reserved_word_pattern = new RegExp('^(?:' + reserved_words.join('|') + ')$');
 
 // var template_pattern = /(?:(?:<\?php|<\?=)[\s\S]*?\?>)|(?:<%[\s\S]*?%>)/g;
@@ -582,5 +586,5 @@ Tokenizer.prototype._read_string_recursive = function(delimiter, allow_unescaped
 
 module.exports.Tokenizer = Tokenizer;
 module.exports.TOKEN = TOKEN;
-module.exports.positionable_operators = positionable_operators.slice();
-module.exports.line_starters = line_starters.slice();
+module.exports.positionable_operators = positionable_operators;
+module.exports.line_starters = line_starters;


### PR DESCRIPTION
References #1

Self-reported metric: 132.7440
Baseline: 125.5390
Summary: Converted special_words, line_starters, and positionable_operators from arrays to Sets for O(1) membership lookups. Modified in_array() to handle both Sets and arrays. This optimization reduced lookup time in hot paths during token classification, resulting in a 5.74% performance improvement (125.5 → 132.7 ops/sec).